### PR TITLE
change method call gometalinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,8 @@
 
 """This module exports the Gometalinter plugin class."""
 
-import os, subprocess
+import os, subprocess, tempfile, re, fnmatch, time
+from os import path
 
 
 from SublimeLinter.lint import Linter, highlight, util
@@ -20,7 +21,7 @@ class Gometalinter(Linter):
     """Provides an interface to gometalinter."""
 
     syntax = ('go', 'gosublime-go', 'gotools')
-    cmd = 'gometalinter * .'
+    cmd = 'gometalinter * '
     regex = r'(?:[^:]+):(?P<line>\d+):(?P<col>\d+)?:(?:(?P<warning>warning)|(?P<error>error)):\s*(?P<message>.*)'
     error_stream = util.STREAM_BOTH
     default_type = highlight.ERROR
@@ -30,7 +31,6 @@ class Gometalinter(Linter):
         Linter.__init__(self, view, syntax)
 
         gopath = self.get_view_settings().get('gopath')
-
         if gopath:
             if self.env:
                 self.env['GOPATH'] = gopath
@@ -41,8 +41,74 @@ class Gometalinter(Linter):
             print('sublimelinter: using system GOPATH={}'.format(os.environ.get('GOPATH', '')))
 
     def run(self, cmd, code):
-        cmd = ' '.join(cmd)+' -I ^%s'%(os.path.basename(self.filename))
+        # return
+        print('--------')
+        files = [f for f in os.listdir(path.dirname(self.filename)) if f.endswith('.go')]
 
+        return self.tmpdir(cmd, files, code)
+
+    # creates tmp directory whith clone structure of gopath direcory by symlinks, write linting file. Change GOPATH env to new tmp dir, execute gometalinter and clear all this.
+    def tmpdir(self, cmd, files, code):
+        filename = path.basename(self.filename)
+        dirname = path.dirname(self.filename)
+
+        gopath = path.expanduser(self.get_view_settings().get('gopath'))
+
+        fakegopath = path.join(tempfile.tempdir,'gometalinter',)
+
+        if not path.exists(fakegopath):
+            os.makedirs(fakegopath)
+
+        fakegopath = tempfile.mkdtemp(dir=fakegopath)
+
+        os.environ['GOPATH']=fakegopath
+        fakepathwd = dirname.replace(gopath, fakegopath)
+
+        if not path.exists(fakepathwd):
+            os.makedirs(fakepathwd)
+
+        if not path.exists(path.join(fakegopath,'pkg')):
+            os.symlink(path.join(gopath,'pkg'),path.join(fakegopath,'pkg'))
+
+        lintfile = path.join(fakepathwd,filename)
+
+        # if path.exists(lintfile):
+        #     os.remove(lintfile)
+
+        f = open(lintfile, 'w+')
+        f.write(code)
+        f.read()
+
+        # recursive creates symlinks from the path of lint file
+        p = dirname
+        while p != gopath:
+            self.linker(p, gopath, fakegopath)
+            p = path.dirname(p)
+
+        os.chdir(fakepathwd)
+        cmd = ' '.join(cmd)+' -I ^%s'%filename
+        out = self.execute(cmd)
+
+        os.environ['GOPATH']=gopath
+        self.removetmpdir(fakegopath)
+
+        return out
+
+    # create symlinks for all files and dirs in directory
+    def linker(self, dirname, gopath, fakegopath):
+        for f in os.listdir(dirname):
+            fakedir = dirname.replace(gopath, fakegopath)
+            target = path.join(fakedir,f)
+            # if path.isfile(target):
+                # os.remove(target)
+            if path.exists(target):
+                continue
+            os.symlink(path.join(dirname,f),target)
+
+        return
+
+    def execute(self, cmd):
+        # time.sleep(3)
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,shell=True)
         (output, err) = p.communicate()
 
@@ -51,7 +117,19 @@ class Gometalinter(Linter):
             print(output)
             print(err)
 
-            return 
-
         if len(output)>0:
             return output.decode('utf-8')
+
+    # clear and remove tmp directory
+    def removetmpdir(self, tmpdir):
+        for root, dirs, files in os.walk(tmpdir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                if path.islink(os.path.join(root, name)):
+                    os.remove(os.path.join(root, name))
+                else:
+                    os.rmdir(os.path.join(root, name))
+
+        os.rmdir(tmpdir)
+                # os.rmdir(os.path.join(root, name))

--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@
 
 """This module exports the Gometalinter plugin class."""
 
-import os, subprocess, re
+import os, subprocess
 
 
 from SublimeLinter.lint import Linter, highlight, util
@@ -41,7 +41,7 @@ class Gometalinter(Linter):
             print('sublimelinter: using system GOPATH={}'.format(os.environ.get('GOPATH', '')))
 
     def run(self, cmd, code):
-        filename = os.path.basename(self.filename)
+        cmd = ' '.join(cmd)+' -I ^%s'%(os.path.basename(self.filename))
 
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,shell=True)
         (output, err) = p.communicate()
@@ -54,13 +54,4 @@ class Gometalinter(Linter):
             return 
 
         if len(output)>0:
-            output = output.decode('utf-8')
-            output = output.splitlines(True)
-
-            clearOut = ''
-            for line in output:
-                if re.match('^%s:'%filename,line):
-                    clearOut+=line
-                    
-            if len(clearOut)>0:
-                return clearOut
+            return output.decode('utf-8')

--- a/linter.py
+++ b/linter.py
@@ -50,7 +50,6 @@ class Gometalinter(Linter):
         filename = path.basename(self.filename)
         dirname = path.dirname(self.filename)
 
-        usergopath = os.environ.get('GOPATH')
         gopath = path.expanduser(self.get_view_settings().get('gopath'))
 
         fakegopath = path.join(tempfile.tempdir,'gometalinter',)
@@ -60,7 +59,6 @@ class Gometalinter(Linter):
 
         fakegopath = tempfile.mkdtemp(dir=fakegopath)
 
-        os.environ['GOPATH']=fakegopath
         fakepathwd = dirname.replace(gopath, fakegopath)
 
         if not path.exists(fakepathwd):
@@ -84,10 +82,10 @@ class Gometalinter(Linter):
             p = path.dirname(p)
 
         os.chdir(fakepathwd)
-        cmd = ' '.join(cmd)+' -I ^%s'%filename
+        cmd = 'GOPATH=%s '%fakegopath+' '.join(cmd)+' -I ^%s'%filename
+
         out = self.execute(cmd)
 
-        os.environ['GOPATH']=usergopath
         self.removetmpdir(fakegopath)
 
         return out

--- a/linter.py
+++ b/linter.py
@@ -10,10 +10,8 @@
 
 """This module exports the Gometalinter plugin class."""
 
-import os, subprocess, tempfile, re, fnmatch, time
+import os, subprocess, tempfile, re, codecs
 from os import path
-
-
 from SublimeLinter.lint import Linter, highlight, util
 
 
@@ -75,9 +73,8 @@ class Gometalinter(Linter):
         # if path.exists(lintfile):
         #     os.remove(lintfile)
 
-        f = open(lintfile, 'w+')
-        f.write(code)
-        f.read()
+        with codecs.open(lintfile, 'w', encoding='utf8') as f:
+            f.write(code)
 
         # recursive creates symlinks from the path of lint file
         p = dirname

--- a/linter.py
+++ b/linter.py
@@ -50,7 +50,7 @@ class Gometalinter(Linter):
         filename = path.basename(self.filename)
         dirname = path.dirname(self.filename)
 
-        gopath = path.expanduser(self.get_view_settings().get('gopath'))
+        gopath = self.determineGopath()
 
         fakegopath = path.join(tempfile.tempdir,'gometalinter',)
 
@@ -102,6 +102,22 @@ class Gometalinter(Linter):
             os.symlink(path.join(dirname,f),target)
 
         return
+
+    def determineGopath(self):
+        gopath = self.get_view_settings().get('gopath')
+        if gopath:
+            return path.expanduser(gopath)
+        
+        if self.env and self.env['GOPATH']:
+            return path.expanduser(self.env['GOPATH'])
+
+        gopath = os.environ.get('GOPATH')
+        if gopath:
+            if ":" in gopath:
+                gopath = gopath.split(':')
+                return gopath[0]
+
+            return gopath
 
     def execute(self, cmd):
         # time.sleep(3)

--- a/linter.py
+++ b/linter.py
@@ -50,6 +50,7 @@ class Gometalinter(Linter):
         filename = path.basename(self.filename)
         dirname = path.dirname(self.filename)
 
+        usergopath = os.environ.get('GOPATH')
         gopath = path.expanduser(self.get_view_settings().get('gopath'))
 
         fakegopath = path.join(tempfile.tempdir,'gometalinter',)
@@ -86,7 +87,7 @@ class Gometalinter(Linter):
         cmd = ' '.join(cmd)+' -I ^%s'%filename
         out = self.execute(cmd)
 
-        os.environ['GOPATH']=gopath
+        os.environ['GOPATH']=usergopath
         self.removetmpdir(fakegopath)
 
         return out


### PR DESCRIPTION
linter function "self.tmpdir" - copy file to tmp directory, it`s not correct for the go language because some imported packages may become inaccessible (ex: vendor dir).

I offer to launch gometalinter directly from the file directory and add -I(--include) flag to filter messages by the current file.

what do you think about it?
