### PR TITLE
Pass extra env to util.communicate

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -55,5 +55,5 @@ class Gometalinter(Linter):
         filename = os.path.basename(self.filename)
         cmd = cmd + ['-I', filename]
         print('gometalinter: in-place linting {}: {}'.format(filename, ' '.join(map(shlex.quote, cmd))))
-        out = util.communicate(cmd, output_stream=util.STREAM_STDOUT)
+        out = util.communicate(cmd, output_stream=util.STREAM_STDOUT, env=self.env)
         return out or ''


### PR DESCRIPTION
I was wondering why `gometalinter` was not working correctly. After some digging I found that the `GOPATH` variable is not set to the value I passed to the `gopath` configuration variable. Though the variable showed up correctly in the debug log it was not passed to `gometalinter`. 

I checked the source of Sublimelinter and there is an extra option `env` in `util.communicate()`. Using that option the variable is passed correctly to `gometalinter`. 
