### PR TITLE
Use --vendor option

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class Gometalinter(Linter):
     """Provides an interface to gometalinter."""
 
     syntax = ('go', 'gosublime-go', 'gotools', 'anacondago-go')
-    cmd = 'gometalinter --fast .'
+    cmd = 'gometalinter --fast --vendor .'
     regex = r'(?:[^:]+):(?P<line>\d+):(?P<col>\d+)?:(?:(?P<warning>warning)|(?P<error>error)):\s*(?P<message>.*)'
     error_stream = util.STREAM_BOTH
     default_type = highlight.ERROR


### PR DESCRIPTION
For user uses go vendoring, gometalinter provide `--vendor` option and we have to use it. 
Or live linting slows down.