### PR TITLE
cls.syntax has been deprecated, set defaults.selector instead

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,11 +21,13 @@ from SublimeLinter.lint.persist import settings
 class Gometalinter(Linter):
     """Provides an interface to gometalinter."""
 
-    syntax = ('go', 'gosublime-go', 'gotools', 'anacondago-go')
     cmd = 'gometalinter --fast .'
     regex = r'(?:[^:]+):(?P<line>\d+):(?P<col>\d+)?:(?:(?P<warning>warning)|(?P<error>error)):\s*(?P<message>.*)'
     error_stream = util.STREAM_BOTH
     default_type = highlight.ERROR
+    defaults = {
+        'selector': 'source.go'
+    }
 
     def run(self, cmd, code):
         if settings.get('lint_mode') == 'background':


### PR DESCRIPTION
Adds support for newer GoSublime syntaxes and fixes the following warning:

    SublimeLinter: WARNING: gometalinter: Defining 'cls.syntax' has been
    deprecated. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector